### PR TITLE
update to motoko 0.6.1

### DIFF
--- a/app/Demo.mo
+++ b/app/Demo.mo
@@ -10,14 +10,16 @@ import QR "canister:qr";
 
 actor {
 
-  type ErrorCorrection = QR.ErrorCorrection;
+/* BUG: rejected as cyclic
+  type ErrorCorrection_ = QR.ErrorCorrection;
   type Mode = QR.Mode;
   type Version = QR.Version;
+*/
 
   public func encode(
-    version : Version,
-    level : ErrorCorrection,
-    mode : Mode,
+    version : QR.Version,
+    level : QR.ErrorCorrection,
+    mode : QR.Mode,
     text : Text
   ) : async Text {
     let result = await QR.encode(version, level, mode, text);

--- a/app/Demo.mo
+++ b/app/Demo.mo
@@ -10,12 +10,6 @@ import QR "canister:qr";
 
 actor {
 
-/* BUG: rejected as cyclic
-  type ErrorCorrection_ = QR.ErrorCorrection;
-  type Mode = QR.Mode;
-  type Version = QR.Version;
-*/
-
   public func encode(
     version : QR.Version,
     level : QR.ErrorCorrection,

--- a/src/Alphanumeric.mo
+++ b/src/Alphanumeric.mo
@@ -14,7 +14,7 @@ import List "mo:base/List";
 import Nat "Nat";
 import Option "mo:base/Option";
 import Prelude "mo:base/Prelude";
-import Prim "mo:prim";
+import Char "mo:base/Char";
 import Text "mo:base/Text";
 import Trie "mo:base/Trie";
 import Util "Util";
@@ -101,7 +101,7 @@ module {
   };
 
   func keyChar(char : Char) : Trie.Key<Char> {
-    { key = char; hash = Prim.charToWord32(char) };
+    { key = char; hash = Char.toNat32(char) };
   };
 
   func eqChar(a : Char, b : Char) : Bool {

--- a/src/Block.mo
+++ b/src/Block.mo
@@ -98,7 +98,7 @@ module {
     let targetSize = Common.targetSize(version, level);
     if (dataSize > targetSize) null else {
 
-      let zeroPadSize =
+      let zeroPadSize : Nat =
         if (dataSize + 7 > targetSize) {
           targetSize - dataSize
         } else {
@@ -106,7 +106,7 @@ module {
         };
       let zeroPad = List.replicate<Bool>(zeroPadSize, false);
 
-      var fillPadSize = targetSize - dataSize - zeroPadSize;
+      var fillPadSize : Nat = targetSize - dataSize - zeroPadSize;
       var fillPad = List.nil<Bool>();
       while (fillPadSize > 0) {
         let chunk = List.take<Bool>(Nat.natToBits(60433), fillPadSize);

--- a/src/Common.mo
+++ b/src/Common.mo
@@ -90,7 +90,7 @@ module {
     level : ErrorCorrection,
     table : [X]
   ) : X {
-    let i = Version.unbox(version) - 1;
+    let i : Nat = Version.unbox(version) - 1;
     let j = switch level {
       case (#L) 0;
       case (#M) 1;

--- a/src/Galois.mo
+++ b/src/Galois.mo
@@ -11,7 +11,7 @@ import Debug "mo:base/Debug";
 import List "mo:base/List";
 import Nat "Nat";
 import Prelude "mo:base/Prelude";
-import Prim "mo:prim";
+import Int "mo:base/Int";
 import Util "Util"
 
 module {
@@ -212,7 +212,7 @@ module {
   };
 
   public func polyOrder(poly : Poly) : Int {
-    Prim.abs(polyLen(polyTrim(poly))) - 1
+    Int.abs(polyLen(polyTrim(poly))) - 1
   };
 
   public func polyLeadCoeff(poly : Poly) : Elem {
@@ -276,12 +276,12 @@ module {
   public type Term = { coeff : Elem; order : Int };
 
   public func polyAddTerm(poly : Poly, term : Term) : Poly {
-    let n = if (term.order <= 0) 0 else Prim.abs(term.order);
+    let n = if (term.order <= 0) 0 else Int.abs(term.order);
     polyAdd(poly, polyPadRight(n, polyNew([term.coeff.unbox])))
   };
 
   public func polyMulTerm(poly : Poly, term : Term) : Poly {
-    let n = if (term.order <= 0) 0 else Prim.abs(term.order);
+    let n = if (term.order <= 0) 0 else Int.abs(term.order);
     polyScale(term.coeff, polyPadRight(n, poly))
   };
 

--- a/src/Nat.mo
+++ b/src/Nat.mo
@@ -7,7 +7,7 @@
  */
 
 import List "mo:base/List";
-import Prim "mo:prim";
+import Nat8 "mo:base/Nat8";
 
 module {
 
@@ -29,45 +29,45 @@ module {
     natZipWith(a, b, func (x, y) { x ^ y })
   };
 
-  public func natMap(a : Nat, f : Word8 -> Word8) : Nat {
-    natFromBytes(List.map<Word8, Word8>(natToBytes(a), f))
+  public func natMap(a : Nat, f : Nat8 -> Nat8) : Nat {
+    natFromBytes(List.map<Nat8, Nat8>(natToBytes(a), f))
   };
 
-  public func natZipWith(a : Nat, b : Nat, f : (Word8, Word8) -> Word8) : Nat {
+  public func natZipWith(a : Nat, b : Nat, f : (Nat8, Nat8) -> Nat8) : Nat {
     var xs = natToBytes(a);
     var ys = natToBytes(b);
-    let xsLen = List.size<Word8>(xs);
-    let ysLen = List.size<Word8>(ys);
+    let xsLen = List.size<Nat8>(xs);
+    let ysLen = List.size<Nat8>(ys);
     if (xsLen < ysLen) {
-      xs := List.append<Word8>(List.replicate<Word8>(ysLen - xsLen, 0), xs);
+      xs := List.append<Nat8>(List.replicate<Nat8>(ysLen - xsLen, 0), xs);
     };
     if (xsLen > ysLen) {
-      ys := List.append<Word8>(List.replicate<Word8>(xsLen - ysLen, 0), xs);
+      ys := List.append<Nat8>(List.replicate<Nat8>(xsLen - ysLen, 0), xs);
     };
-    let zs = List.zipWith<Word8, Word8, Word8>(xs, ys, f);
+    let zs = List.zipWith<Nat8, Nat8, Nat8>(xs, ys, f);
     let c = natFromBytes(zs);
     c
   };
 
-  public func natToBytes(n : Nat) : List<Word8> {
+  public func natToBytes(n : Nat) : List<Nat8> {
     var a = 0;
     var b = n;
-    var bytes = List.nil<Word8>();
+    var bytes = List.nil<Nat8>();
     var test = true;
     while test {
       a := b % 256;
       b := b / 256;
-      bytes := List.push<Word8>(Prim.natToWord8(a), bytes);
+      bytes := List.push<Nat8>(Nat8.fromNat(a), bytes);
       test := b > 0;
     };
     bytes
   };
 
-  public func natFromBytes(bytes : List<Word8>) : Nat {
+  public func natFromBytes(bytes : List<Nat8>) : Nat {
     var n = 0;
     var i = 0;
-    List.foldRight<Word8, ()>(bytes, (), func (byte, _) {
-      n += Prim.word8ToNat(byte) * 256 ** i;
+    List.foldRight<Nat8, ()>(bytes, (), func (byte, _) {
+      n += Nat8.toNat(byte) * 256 ** i;
       i += 1;
     });
     n

--- a/src/Numeric.mo
+++ b/src/Numeric.mo
@@ -11,8 +11,9 @@ import Common "Common";
 import Iter "mo:base/Iter";
 import List "mo:base/List";
 import Nat "Nat";
+import Nat32 "mo:base/Nat32";
 import Option "mo:base/Option";
-import Prim "mo:prim";
+import Int "mo:base/Int";
 import Text "mo:base/Text";
 import Util "Util";
 import Version "Version";
@@ -66,12 +67,12 @@ module {
       case _ null
     };
 
-    //
+    // 
     let n = List.foldLeft<Char, ?Nat>(chunk, ?0, func (accum, char) {
       if (Char.isDigit(char)) {
         Option.map<Nat, Nat>(accum, func (a) {
-          let b = Prim.word32ToNat(
-            Prim.charToWord32(char) -% Prim.charToWord32('0')
+          let b = Nat32.toNat(
+            Char.toNat32(char) - Char.toNat32('0')
           );
           10 * a + b
         })

--- a/src/Symbol.mo
+++ b/src/Symbol.mo
@@ -92,7 +92,7 @@ module {
 
   func finderTLCoords(version : Version) : List<Coordinate> {
     let w = Common.width(version);
-    let v = w - 8;
+    let v : Nat = w - 8;
     var coords = List.nil<Coordinate>();
     for (i in Iter.range(v, w - 1)) {
       for (j in Iter.range(v, w - 1)) {
@@ -110,7 +110,7 @@ module {
 
   func finderTRCoords(version : Version) : List<Coordinate> {
     let w = Common.width(version);
-    let r = w - 8;
+    let r : Nat = w - 8;
     var coords = List.nil<Coordinate>();
     for (i in Iter.range(r, w - 1)) {
       for (j in Iter.range(0, 7)) {
@@ -128,7 +128,7 @@ module {
 
   func finderBLCoords(version : Version) : List<Coordinate> {
     let w = Common.width(version);
-    let c = w - 8;
+    let c : Nat = w - 8;
     var coords = List.nil<Coordinate>();
     for (i in Iter.range(0, 7)) {
       for (j in Iter.range(c, w - 1)) {
@@ -162,7 +162,7 @@ module {
 
   func timingHCoords(version : Version) : List<Coordinate> {
     let w = Common.width(version);
-    let r = w - 7;
+    let r : Nat = w - 7;
     var coords = List.nil<Coordinate>();
     for (j in Iter.range(8, w - 9)) {
       coords := List.push<Coordinate>((r, j), coords)
@@ -197,7 +197,7 @@ module {
 
   func hardcodeCoords(version : Version) : List<Coordinate> {
     let w = Common.width(version);
-    let c = w - 9;
+    let c : Nat = w - 9;
     List.make<Coordinate>((7, c))
   };
 
@@ -227,8 +227,8 @@ module {
 
   func formatHCoords(version : Version) : List<Coordinate> {
     let w = Common.width(version);
-    let r = w - 9;
-    let c = w - 8;
+    let r : Nat = w - 9;
+    let c : Nat = w - 8;
     var coords = List.nil<Coordinate>();
     for (j in Iter.range(0, 7)) {
       coords := List.push<Coordinate>((r, j), coords)
@@ -244,7 +244,7 @@ module {
 
   func formatVCoords(version : Version) : List<Coordinate> {
     let w = Common.width(version);
-    let c = w - 9;
+    let c : Nat = w - 9;
     var coords = List.nil<Coordinate>();
     for (i in Iter.range(0, 6)) {
       coords := List.push<Coordinate>((i, c), coords)
@@ -303,7 +303,7 @@ module {
 
   func alignment(version : Version) : List<(Coordinate, Bool)> {
     let n = Common.alignments(version).size() ** 2;
-    let m = if (n < 4) 0 else n - 3;
+    let m : Nat = if (n < 4) 0 else n - 3;
     let coords = alignmentCoords(version);
     let pattern = Nat.natToBits(33084991);
     let cycles = List.flatten<Bool>(List.replicate<List<Bool>>(m, pattern));
@@ -381,7 +381,7 @@ module {
   func traceCoords(version : Version) : List<Coordinate> {
 
     let w = Common.width(version);
-    let t = w - 7;
+    let t : Nat = w - 7;
 
     let up = List.flatten<Nat>(List.map<Nat, List<Nat>>(
       Iter.toList<Nat>(Iter.range(0, w - 1)),


### PR DESCRIPTION
- remove mo:prim imports
- ~Word32~ -> Nat32 (please check I didn't make mistakes).
- workaround for moc bug #2529:

Manual test output (looks fish to me so please review - is the bottom right corner incorrect?

```
crusso@vm:~/motoko-qr$ ./run.sh

== Build.

May 13 21:57:33.329 INFO ic-starter. Configuration: ValidatedConfig { replica_path: Some("/home/crusso/.cache/dfinity/versions/0.7.0-beta.8/replica"), replica_version: "0.1.0", log_level: Warning, cargo_bin: "cargo", cargo_opts: "", state_dir: "/home/crusso/motoko-qr/.dfx/state/replicated_state", http_listen_addr: V4(127.0.0.1:0), http_port_file: Some("/home/crusso/motoko-qr/.dfx/replica-configuration/replica-1.port"), metrics_addr: None, provisional_whitelist: Some(All), artifact_pool_dir: "/home/crusso/motoko-qr/.dfx/state/replicated_state/node-100/ic_consensus_pool", artifact_backup_dir: None, crypto_root: "/home/crusso/motoko-qr/.dfx/state/replicated_state/node-100/crypto", state_manager_root: "/home/crusso/motoko-qr/.dfx/state/replicated_state/node-100/state", registry_local_store_path: "/home/crusso/motoko-qr/.dfx/state/replicated_state/ic_registry_local_store", unit_delay: None, initial_notary_delay: None, detect_consensus_starvation: None, consensus_pool_backend: Some("rocksdb"), state_dir_holder: None }, Application: starter
May 13 21:57:33.329 INFO Initialize replica configuration "/home/crusso/motoko-qr/.dfx/state/replicated_state/ic.json5", Application: starter
May 13 21:57:34.118 INFO Executing "/home/crusso/.cache/dfinity/versions/0.7.0-beta.8/replica" "--replica-version" "0.1.0" "--config-file" "/home/crusso/motoko-qr/.dfx/state/replicated_state/ic.json5", Application: starter
Starting webserver for replica at "http://localhost:34893"
binding to: V4(127.0.0.1:8000)
replica(s): http://localhost:34893/
Creating a wallet canister on the local network.
The wallet canister on the "local" network for user "crusso" is "rwlgt-iiaaa-aaaaa-aaaaa-cai"
Creating canister "demo"...
"demo" canister created with canister id: "rrkah-fqaaa-aaaaa-aaaaq-cai"
Creating canister "format"...
"format" canister created with canister id: "ryjl3-tyaaa-aaaaa-aaaba-cai"
Creating canister "galois"...
"galois" canister created with canister id: "r7inp-6aaaa-aaaaa-aaabq-cai"
Creating canister "qr"...
"qr" canister created with canister id: "rkp4c-7iaaa-aaaaa-aaaca-cai"
Creating canister "test"...
"test" canister created with canister id: "rno2w-sqaaa-aaaaa-aaacq-cai"
Creating canister "version"...
"version" canister created with canister id: "renrk-eyaaa-aaaaa-aaada-cai"
Building canisters...

== Test.

Creating UI canister on the local network.
The UI canister on the "local" network is "rdmx6-jaaaa-aaaaa-aaadq-cai"
Installing code for canister demo, with canister_id rrkah-fqaaa-aaaaa-aaaaq-cai
Installing code for canister format, with canister_id ryjl3-tyaaa-aaaaa-aaaba-cai
Installing code for canister galois, with canister_id r7inp-6aaaa-aaaaa-aaabq-cai
Installing code for canister qr, with canister_id rkp4c-7iaaa-aaaaa-aaaca-cai
Installing code for canister test, with canister_id rno2w-sqaaa-aaaaa-aaacq-cai
Installing code for canister version, with canister_id renrk-eyaaa-aaaaa-aaada-cai
()

== Demo.

01234567


  
██████████████  ████  ████  ██████████████
██          ██  ██  ██      ██          ██
██  ██████  ██    ████  ██  ██  ██████  ██
██  ██████  ██  ████        ██  ██████  ██
██  ██████  ██    ████      ██  ██████  ██
██          ██    ████      ██          ██
██████████████  ██  ██  ██  ██████████████
                ████                      
██  ████  ██████    ██      ██    ██  ████
      ██  ██  ████  ██  ██    ██  ████    
██    ██  ████████      ██████████    ██  
████  ██      ██    ██  ████      ██  ██  
      ████████████    ██  ██    ██        
                ██████    ██  ██        ██
██████████████  ██        ████  ██  ████  
██          ██  ██  ██████████      ██  ██
██  ██████  ██    ██  ██    ██          ██
██  ██████  ██  ██  ██    ██    ██  ████  
██  ██████  ██  ██  ████  ██    ██  ██    
██          ██    ██  ████  ██  ████  ████
██████████████  ██    ████    ██      ██  
,


HELLO WORLD


  
██████████████      ██      ██████████████
██          ██  ████  ██    ██          ██
██  ██████  ██  ██    ██    ██  ██████  ██
██  ██████  ██        ████  ██  ██████  ██
██  ██████  ██        ████  ██  ██████  ██
██          ██    ██  ██    ██          ██
██████████████  ██  ██  ██  ██████████████
                  ██                      
  ██████  ████                      ████  
██        ██  ████████  ████    ██████████
██  ██████  ████  ██  ████  ██      ██    
  ██████      ██  ██      ██    ██  ████  
██  ████    ██    ██  ████          ██    
                ██    ██  ██  ██    ████  
██████████████      ██  ████████  ██  ████
██          ██  ████      ██████    ████  
██  ██████  ██        ████  ████      ████
██  ██████  ██  ██  ██    ██    ████  ██  
██  ██████  ██  ████████  ██    ████      
██          ██  ██████████  ████  ██      
██████████████        ████    ██    ████  
,
```
